### PR TITLE
Fix withKeyStartingWith return type

### DIFF
--- a/src/main/java/io/github/dyegosutil/awspresignedpost/conditions/KeyConditionUtil.java
+++ b/src/main/java/io/github/dyegosutil/awspresignedpost/conditions/KeyConditionUtil.java
@@ -28,7 +28,7 @@ public class KeyConditionUtil {
      *     user
      * @return {@link KeyStartingWithCondition}
      */
-    public static KeyCondition withKeyStartingWith(String value) {
+    public static KeyStartingWithCondition withKeyStartingWith(String value) {
         return new KeyStartingWithCondition(value);
     }
 

--- a/src/test/java/io/github/dyegosutil/awspresignedpost/integrationtests/accesskey/akia/PreSignedPostMandatoryPostParamsIntegrationTests.java
+++ b/src/test/java/io/github/dyegosutil/awspresignedpost/integrationtests/accesskey/akia/PreSignedPostMandatoryPostParamsIntegrationTests.java
@@ -84,11 +84,11 @@ public class PreSignedPostMandatoryPostParamsIntegrationTests extends Integratio
             Region region, ZonedDateTime expirationDate, String bucket, KeyCondition keyCondition) {
         if (keyCondition instanceof ExactKeyCondition) {
             return createPostParamsWithExactKeyCondition(
-                    region, expirationDate, bucket, keyCondition);
+                    region, expirationDate, bucket, (ExactKeyCondition) keyCondition);
         }
         if (keyCondition instanceof KeyStartingWithCondition) {
             return createPostParamsWithKeyStartingWithCondition(
-                    region, expirationDate, bucket, keyCondition);
+                    region, expirationDate, bucket, (KeyStartingWithCondition) keyCondition);
         }
         throw new IllegalArgumentException(
                 "Cannot create PostParams. Only ExactKeyCondition and KeyStartingWithCondition are"
@@ -96,28 +96,20 @@ public class PreSignedPostMandatoryPostParamsIntegrationTests extends Integratio
     }
 
     private PostParams createPostParamsWithExactKeyCondition(
-            Region region, ZonedDateTime expirationDate, String bucket, KeyCondition keyCondition) {
+            Region region, ZonedDateTime expirationDate, String bucket, ExactKeyCondition exactKeyCondition) {
         return PostParams.builder(
-                        region, expirationDate, bucket, castToExactKeyCondition(keyCondition))
+                        region, expirationDate, bucket, exactKeyCondition)
                 .build();
     }
 
     private PostParams createPostParamsWithKeyStartingWithCondition(
-            Region region, ZonedDateTime expirationDate, String bucket, KeyCondition keyCondition) {
+            Region region, ZonedDateTime expirationDate, String bucket, KeyStartingWithCondition keyStartingWithCondition) {
         return PostParams.builder(
                         region,
                         expirationDate,
                         bucket,
-                        castToKeyStartingWithCondition(keyCondition))
+                        keyStartingWithCondition)
                 .build();
-    }
-
-    private ExactKeyCondition castToExactKeyCondition(KeyCondition keyCondition) {
-        return (ExactKeyCondition) keyCondition;
-    }
-
-    private KeyStartingWithCondition castToKeyStartingWithCondition(KeyCondition keyCondition) {
-        return (KeyStartingWithCondition) keyCondition;
     }
 
     private static Stream<Arguments> getCustomizedUploadConditionsTestCases() {

--- a/src/test/java/io/github/dyegosutil/awspresignedpost/integrationtests/accesskey/akia/PreSignedPostMandatoryPostParamsIntegrationTests.java
+++ b/src/test/java/io/github/dyegosutil/awspresignedpost/integrationtests/accesskey/akia/PreSignedPostMandatoryPostParamsIntegrationTests.java
@@ -96,20 +96,19 @@ public class PreSignedPostMandatoryPostParamsIntegrationTests extends Integratio
     }
 
     private PostParams createPostParamsWithExactKeyCondition(
-            Region region, ZonedDateTime expirationDate, String bucket, ExactKeyCondition exactKeyCondition) {
-        return PostParams.builder(
-                        region, expirationDate, bucket, exactKeyCondition)
-                .build();
+            Region region,
+            ZonedDateTime expirationDate,
+            String bucket,
+            ExactKeyCondition exactKeyCondition) {
+        return PostParams.builder(region, expirationDate, bucket, exactKeyCondition).build();
     }
 
     private PostParams createPostParamsWithKeyStartingWithCondition(
-            Region region, ZonedDateTime expirationDate, String bucket, KeyStartingWithCondition keyStartingWithCondition) {
-        return PostParams.builder(
-                        region,
-                        expirationDate,
-                        bucket,
-                        keyStartingWithCondition)
-                .build();
+            Region region,
+            ZonedDateTime expirationDate,
+            String bucket,
+            KeyStartingWithCondition keyStartingWithCondition) {
+        return PostParams.builder(region, expirationDate, bucket, keyStartingWithCondition).build();
     }
 
     private static Stream<Arguments> getCustomizedUploadConditionsTestCases() {


### PR DESCRIPTION
As identified by [SIMULATAN](https://github.com/SIMULATAN)  in the [raised fix PR](https://github.com/dyegosutil/aws-s3-presigned-post/pull/252), the return type of `KeyConditionUtil.withKeyStartingWith()` should be `KeyStartingWithCondition` and not `KeyCondition`.

This PR reflect the changes in the tests.